### PR TITLE
Add multi-passive MemTable buffers to ensure hybrid correctness during flush

### DIFF
--- a/config/dev.toml
+++ b/config/dev.toml
@@ -16,6 +16,7 @@ event_per_zone = 2
 compaction_threshold = 8
 compaction_interval = 300
 sys_io_threshold = 10
+max_inflight_passives = 8
 
 
 [schema]

--- a/config/prod.toml
+++ b/config/prod.toml
@@ -16,6 +16,7 @@ event_per_zone = 2048
 compaction_threshold = 8
 compaction_interval = 300
 sys_io_threshold = 100
+max_inflight_passives = 32
 
 
 [schema]

--- a/config/test.toml
+++ b/config/test.toml
@@ -16,6 +16,7 @@ event_per_zone = 2
 compaction_threshold = 8
 compaction_interval = 300
 sys_io_threshold = 10
+max_inflight_passives = 8
 
 
 [schema]

--- a/src/engine/core/memory/mod.rs
+++ b/src/engine/core/memory/mod.rs
@@ -1,4 +1,5 @@
 pub mod memtable;
+pub mod passive_buffer_set;
 
 #[cfg(test)]
 mod memtable_tests;

--- a/src/engine/core/memory/passive_buffer_set.rs
+++ b/src/engine/core/memory/passive_buffer_set.rs
@@ -1,0 +1,77 @@
+use super::memtable::MemTable;
+use std::sync::Arc;
+use tokio::sync::Mutex;
+
+/// Manages multiple passive MemTables that are awaiting flush.
+/// Each rotation creates a new passive buffer; queries should read from all non-empty buffers.
+#[derive(Debug)]
+pub struct PassiveBufferSet {
+    buffers: Mutex<Vec<Arc<Mutex<MemTable>>>>,
+    max_inflight: usize,
+}
+
+impl PassiveBufferSet {
+    pub fn new(max_inflight: usize) -> Self {
+        Self {
+            buffers: Mutex::new(Vec::new()),
+            max_inflight,
+        }
+    }
+
+    pub fn max_inflight(&self) -> usize {
+        self.max_inflight
+    }
+
+    /// Add a new passive buffer cloned from the given active MemTable.
+    /// Returns the Arc to the specific passive buffer, which should be passed to the flush worker.
+    pub async fn add_from(&self, source: &MemTable) -> Arc<Mutex<MemTable>> {
+        let passive = Arc::new(Mutex::new(source.clone()));
+
+        let mut guard = self.buffers.lock().await;
+        // Enforce a simple cap by dropping the oldest empty buffers first, then blocking growth.
+        if guard.len() >= self.max_inflight {
+            // Try to prune empties to make space
+            guard.retain(|buf| {
+                // Retain if non-empty; empty buffers will be dropped
+                // Note: try_lock to avoid await inside retain; if contended, keep it.
+                if let Ok(inner) = buf.try_lock() {
+                    inner.len() > 0
+                } else {
+                    true
+                }
+            });
+        }
+
+        guard.push(Arc::clone(&passive));
+        passive
+    }
+
+    /// Returns a snapshot vector of all non-empty passive buffers.
+    pub async fn non_empty(&self) -> Vec<Arc<Mutex<MemTable>>> {
+        let guard = self.buffers.lock().await;
+        let mut out = Vec::with_capacity(guard.len());
+        for buf in guard.iter() {
+            if let Ok(inner) = buf.try_lock() {
+                if inner.len() > 0 {
+                    out.push(Arc::clone(buf));
+                }
+            } else {
+                // If contended, include it to be safe; query will lock later
+                out.push(Arc::clone(buf));
+            }
+        }
+        out
+    }
+
+    /// Remove empty buffers from the set. Best-effort.
+    pub async fn prune_empties(&self) {
+        let mut guard = self.buffers.lock().await;
+        guard.retain(|buf| {
+            if let Ok(inner) = buf.try_lock() {
+                inner.len() > 0
+            } else {
+                true
+            }
+        });
+    }
+}

--- a/src/engine/core/read/memtable_query_runner_test.rs
+++ b/src/engine/core/read/memtable_query_runner_test.rs
@@ -60,7 +60,8 @@ async fn runs_memtable_query_runner_and_returns_matching_events() {
         .unwrap();
 
     // Run the MemTableQueryRunner
-    let runner = MemTableQueryRunner::new(Some(&memtable), None, &plan);
+    let passives: Vec<&Arc<tokio::sync::Mutex<crate::engine::core::MemTable>>> = Vec::new();
+    let runner = MemTableQueryRunner::new(Some(&memtable), &passives, &plan);
     let result = runner.run().await;
 
     // Verify: Only the "shipped" event is returned
@@ -90,7 +91,8 @@ async fn returns_empty_when_memtable_is_none() {
         .create()
         .await;
 
-    let runner = MemTableQueryRunner::new(None, None, &plan);
+    let passives: Vec<&Arc<tokio::sync::Mutex<crate::engine::core::MemTable>>> = Vec::new();
+    let runner = MemTableQueryRunner::new(None, &passives, &plan);
     let result = runner.run().await;
 
     // Verify: result is empty when no memtable provided

--- a/src/engine/query/scan.rs
+++ b/src/engine/query/scan.rs
@@ -1,5 +1,6 @@
 use crate::command::types::Command;
 use crate::engine::core::{Event, MemTable, QueryExecution, QueryPlan};
+use crate::engine::core::memory::passive_buffer_set::PassiveBufferSet;
 use crate::engine::errors::QueryExecutionError;
 use crate::engine::schema::registry::SchemaRegistry;
 use std::path::Path;
@@ -14,7 +15,7 @@ pub async fn scan(
     segment_base_dir: &Path,
     segment_ids: &Arc<std::sync::RwLock<Vec<String>>>,
     memtable: &MemTable,
-    passive_memtable: &Arc<Mutex<MemTable>>,
+    passive_buffers: &Arc<PassiveBufferSet>,
 ) -> Result<Vec<Event>, QueryExecutionError> {
     debug!(
         target: "engine::query::scan",
@@ -38,9 +39,12 @@ pub async fn scan(
     };
 
     // Step 2: Execute query over memtable and disk
+    let passives = passive_buffers.non_empty().await;
+    let passive_refs: Vec<&Arc<Mutex<MemTable>>> = passives.iter().collect();
+
     let mut execution = QueryExecution::new(&plan)
         .with_memtable(memtable)
-        .with_passive_memtable(passive_memtable);
+        .with_passive_memtables(passive_refs);
 
     let results = execution.run().await?;
     info!(

--- a/src/engine/query/scan_test.rs
+++ b/src/engine/query/scan_test.rs
@@ -1,6 +1,7 @@
 use crate::command::types::{CompareOp, Expr};
 use crate::engine::core::Flusher;
 use crate::engine::core::MemTable;
+use crate::engine::core::memory::passive_buffer_set::PassiveBufferSet;
 use crate::engine::query::scan::scan;
 use crate::test_helpers::factories::{
     CommandFactory, EventFactory, MemTableFactory, SchemaRegistryFactory,
@@ -41,7 +42,7 @@ async fn scan_query_returns_expected_events() {
         .create()
         .unwrap();
 
-    let passive_memtable = Arc::new(tokio::sync::Mutex::new(MemTable::new(2)));
+    let passive_buffers = Arc::new(PassiveBufferSet::new(8));
 
     let flusher = Flusher::new(memtable.clone(), 1, &segment_base_dir, registry.clone());
     flusher.flush().await.expect("Flush failed");
@@ -58,7 +59,7 @@ async fn scan_query_returns_expected_events() {
         &segment_base_dir,
         &segment_ids,
         &memtable,
-        &passive_memtable,
+        &passive_buffers,
     )
     .await
     .expect("scan failed");
@@ -101,7 +102,7 @@ async fn scan_where_expr_logic() {
         .create()
         .unwrap();
 
-    let passive_memtable = Arc::new(tokio::sync::Mutex::new(MemTable::new(2)));
+    let passive_buffers = Arc::new(PassiveBufferSet::new(8));
 
     let cases: Vec<(Expr, Vec<&str>)> = vec![
         (
@@ -201,7 +202,7 @@ async fn scan_where_expr_logic() {
             tmp_dir.path(),
             &segment_ids,
             &memtable,
-            &passive_memtable,
+            &passive_buffers,
         )
         .await
         .unwrap();
@@ -242,7 +243,7 @@ async fn scan_query_with_context_id_and_expr_logic() {
             .create(),
     ];
     let memtable = MemTableFactory::new().with_events(events).create().unwrap();
-    let passive_memtable = Arc::new(tokio::sync::Mutex::new(MemTable::new(2)));
+    let passive_buffers = Arc::new(PassiveBufferSet::new(8));
 
     // 1. Filter by context_id only
     let cmd = CommandFactory::query().with_context_id("ctx1").create();
@@ -252,7 +253,7 @@ async fn scan_query_with_context_id_and_expr_logic() {
         dir.path(),
         &segment_ids,
         &memtable,
-        &passive_memtable,
+        &passive_buffers,
     )
     .await
     .unwrap();
@@ -275,7 +276,7 @@ async fn scan_query_with_context_id_and_expr_logic() {
         dir.path(),
         &segment_ids,
         &memtable,
-        &passive_memtable,
+        &passive_buffers,
     )
     .await
     .unwrap();
@@ -298,7 +299,7 @@ async fn scan_query_with_context_id_and_expr_logic() {
         dir.path(),
         &segment_ids,
         &memtable,
-        &passive_memtable,
+        &passive_buffers,
     )
     .await
     .unwrap();
@@ -321,7 +322,7 @@ async fn scan_query_with_context_id_and_expr_logic() {
         dir.path(),
         &segment_ids,
         &memtable,
-        &passive_memtable,
+        &passive_buffers,
     )
     .await
     .unwrap();
@@ -350,7 +351,7 @@ async fn scan_query_with_context_id_and_expr_logic() {
         dir.path(),
         &segment_ids,
         &memtable,
-        &passive_memtable,
+        &passive_buffers,
     )
     .await
     .unwrap();

--- a/src/engine/replay/scan_test.rs
+++ b/src/engine/replay/scan_test.rs
@@ -4,6 +4,7 @@ use crate::test_helpers::factories::{
 };
 use serde_json::json;
 use std::sync::Arc;
+use crate::engine::core::memory::passive_buffer_set::PassiveBufferSet;
 use std::time::{SystemTime, UNIX_EPOCH};
 
 #[tokio::test]
@@ -54,9 +55,7 @@ async fn scan_replay_with_context_id_and_time_logic() {
             .create(),
     ];
     let memtable = MemTableFactory::new().with_events(events).create().unwrap();
-    let passive_memtable = Arc::new(tokio::sync::Mutex::new(
-        MemTableFactory::new().create().unwrap(),
-    ));
+    let passive_buffers = Arc::new(PassiveBufferSet::new(8));
 
     // 1. Replay ctx1 with no `since` (should include)
     let cmd = CommandFactory::replay().with_context_id("ctx1").create();
@@ -66,7 +65,7 @@ async fn scan_replay_with_context_id_and_time_logic() {
         dir.path(),
         &segment_ids,
         &memtable,
-        &passive_memtable,
+        &passive_buffers,
     )
     .await
     .unwrap();
@@ -85,7 +84,7 @@ async fn scan_replay_with_context_id_and_time_logic() {
         dir.path(),
         &segment_ids,
         &memtable,
-        &passive_memtable,
+        &passive_buffers,
     )
     .await
     .unwrap();
@@ -104,7 +103,7 @@ async fn scan_replay_with_context_id_and_time_logic() {
         dir.path(),
         &segment_ids,
         &memtable,
-        &passive_memtable,
+        &passive_buffers,
     )
     .await
     .unwrap();
@@ -122,7 +121,7 @@ async fn scan_replay_with_context_id_and_time_logic() {
         dir.path(),
         &segment_ids,
         &memtable,
-        &passive_memtable,
+        &passive_buffers,
     )
     .await
     .unwrap();
@@ -141,7 +140,7 @@ async fn scan_replay_with_context_id_and_time_logic() {
         dir.path(),
         &segment_ids,
         &memtable,
-        &passive_memtable,
+        &passive_buffers,
     )
     .await
     .unwrap();
@@ -158,7 +157,7 @@ async fn scan_replay_with_context_id_and_time_logic() {
         dir.path(),
         &segment_ids,
         &memtable,
-        &passive_memtable,
+        &passive_buffers,
     )
     .await
     .unwrap();

--- a/src/engine/store/insert_test.rs
+++ b/src/engine/store/insert_test.rs
@@ -173,7 +173,7 @@ async fn test_insert_and_maybe_flush_e2e() {
         &ctx.base_dir,
         &ctx.segment_ids,
         &ctx.memtable,
-        &ctx.passive_memtable,
+        &ctx.passive_buffers,
     )
     .await
     .unwrap();

--- a/src/shared/config/model.rs
+++ b/src/shared/config/model.rs
@@ -35,6 +35,7 @@ pub struct EngineConfig {
     pub compaction_threshold: usize,
     pub compaction_interval: u64,
     pub sys_io_threshold: usize,
+    pub max_inflight_passives: Option<usize>,
 }
 
 impl EngineConfig {

--- a/tests/helpers/factories/shard_context_factory.rs
+++ b/tests/helpers/factories/shard_context_factory.rs
@@ -1,4 +1,5 @@
 use crate::engine::core::{FlushManager, MemTable, WalHandle};
+use crate::engine::core::memory::passive_buffer_set::PassiveBufferSet;
 use crate::engine::shard::context::ShardContext;
 use crate::shared::config::CONFIG;
 use std::path::PathBuf;
@@ -76,9 +77,7 @@ impl ShardContextFactory {
             flush_count: 0,
             wal: Some(wal),
             flush_manager,
-            passive_memtable: Arc::new(tokio::sync::Mutex::new(MemTable::new(
-                CONFIG.engine.flush_threshold,
-            ))),
+            passive_buffers: Arc::new(PassiveBufferSet::new(8)),
         };
 
         ctx

--- a/tests/integration/config.rs
+++ b/tests/integration/config.rs
@@ -36,6 +36,7 @@ pub struct EngineConfig {
     pub compaction_threshold: usize,
     pub compaction_interval: u64,
     pub sys_io_threshold: usize,
+    pub max_inflight_passives: usize,
 }
 
 #[derive(Serialize)]
@@ -71,7 +72,7 @@ pub fn write_config_for(name: &str) -> (String, String) {
             fsync_every_n: None,
         },
         engine: EngineConfig {
-            flush_threshold: 6,
+            flush_threshold: 2,
             data_dir: format!("{}/data", base_dir),
             index_dir: format!("{}/index", base_dir),
             shard_count: 2,
@@ -79,6 +80,7 @@ pub fn write_config_for(name: &str) -> (String, String) {
             compaction_threshold: 10,
             compaction_interval: 10,
             sys_io_threshold: 10,
+            max_inflight_passives: 8,
         },
         server: ServerConfig {
             socket_path: socket_path.clone(),


### PR DESCRIPTION
- Introduces PassiveBufferSet to manage multiple passive MemTables while flushes are in-flight.
- Refactors insert/flush/query paths to prevent data gaps caused by overwriting a single passive buffer.
- Adds optional engine.max_inflight_passives config; defaults to 8 when not set.
- Adds opportunistic pruning to keep passive buffers tidy during high churn.