### PR TITLE
Capture RETURN fields for QUERY/REPLAY

### DIFF
--- a/src/engine/core/read/mod.rs
+++ b/src/engine/core/read/mod.rs
@@ -1,6 +1,7 @@
 pub mod execution_step;
 pub mod memtable_query;
 pub mod memtable_query_runner;
+pub mod projection;
 pub mod query_execution;
 pub mod query_plan;
 pub mod range_query_handler;
@@ -12,6 +13,8 @@ mod execution_step_test;
 mod memtable_query_runner_test;
 #[cfg(test)]
 mod memtable_query_test;
+#[cfg(test)]
+mod projection_test;
 #[cfg(test)]
 mod query_execution_test;
 #[cfg(test)]

--- a/src/engine/core/read/projection.rs
+++ b/src/engine/core/read/projection.rs
@@ -1,0 +1,113 @@
+use std::collections::HashSet;
+
+use crate::command::types::Command;
+use crate::engine::core::QueryPlan;
+use tracing::{debug, info};
+
+/// Projection policy derived from the RETURN clause
+enum ProjectionMode {
+    /// Load all payload columns
+    AllPayload,
+    /// Load only the listed fields (plus cores and filters)
+    Fields(Vec<String>),
+}
+
+/// Computes the minimal set of columns that need to be loaded
+/// for a given `QueryPlan`, taking filters and RETURN projection into account.
+pub struct ProjectionPlanner<'a> {
+    plan: &'a QueryPlan,
+}
+
+impl<'a> ProjectionPlanner<'a> {
+    pub fn new(plan: &'a QueryPlan) -> Self {
+        Self { plan }
+    }
+
+    pub async fn columns_to_load(&self) -> Vec<String> {
+        // Start with core fields
+        let mut needed = self.core_fields();
+        debug!(target: "query::projection", core=?needed, "Initialized core projection fields");
+
+        // Add filter columns (from filter plans)
+        let filter_cols = self.collect_filter_columns();
+        debug!(target: "query::projection", ?filter_cols, "Collected filter columns from plans");
+        needed.extend(filter_cols);
+
+        // Determine projection mode and payload fields from schema
+        let mode = self.resolve_projection_mode();
+        info!(target: "query::projection", event_type=%self.plan.event_type(), mode=?proj_mode_to_str(&mode), "Resolved projection mode");
+        let all_payload = self.all_payload_fields(self.plan.event_type()).await;
+        debug!(target: "query::projection", payload_fields=?all_payload, count=all_payload.len(), "Resolved payload fields from schema");
+
+        match mode {
+            ProjectionMode::AllPayload => {
+                debug!(target: "query::projection", "Including all payload fields due to mode=AllPayload");
+                needed.extend(all_payload);
+            }
+            ProjectionMode::Fields(list) => {
+                let projected: HashSet<String> = list
+                    .iter()
+                    .filter(|f| Self::is_core_field(f) || all_payload.contains(*f))
+                    .cloned()
+                    .collect();
+                debug!(target: "query::projection", requested=?list, selected=?projected, "Filtered requested fields against schema and core");
+                needed.extend(projected);
+            }
+        }
+
+        let cols: Vec<String> = needed.into_iter().collect();
+        info!(target: "query::projection", columns=?cols, "Final columns to load computed");
+        cols
+    }
+
+    fn core_fields(&self) -> HashSet<String> {
+        [
+            "context_id".to_string(),
+            "event_type".to_string(),
+            "timestamp".to_string(),
+        ]
+        .into_iter()
+        .collect()
+    }
+
+    fn is_core_field(name: &str) -> bool {
+        matches!(name, "context_id" | "event_type" | "timestamp")
+    }
+
+    fn collect_filter_columns(&self) -> HashSet<String> {
+        let mut cols = HashSet::new();
+        for filter in &self.plan.filter_plans {
+            if filter.operation.is_some() {
+                cols.insert(filter.column.clone());
+            }
+        }
+        cols
+    }
+
+    fn resolve_projection_mode(&self) -> ProjectionMode {
+        if let Command::Query { return_fields, .. } = &self.plan.command {
+            match return_fields {
+                None => ProjectionMode::AllPayload,
+                Some(v) if v.is_empty() => ProjectionMode::AllPayload,
+                Some(v) => ProjectionMode::Fields(v.clone()),
+            }
+        } else {
+            ProjectionMode::AllPayload
+        }
+    }
+
+    async fn all_payload_fields(&self, event_type: &str) -> HashSet<String> {
+        if let Some(schema) = self.plan.registry.read().await.get(event_type) {
+            schema.fields().cloned().collect()
+        } else {
+            HashSet::new()
+        }
+    }
+}
+
+fn proj_mode_to_str(mode: &ProjectionMode) -> &'static str {
+    match mode {
+        ProjectionMode::AllPayload => "AllPayload",
+        ProjectionMode::Fields(_) => "Fields",
+    }
+}

--- a/src/engine/core/read/projection_test.rs
+++ b/src/engine/core/read/projection_test.rs
@@ -1,0 +1,216 @@
+use crate::command::types::{Command, CompareOp, Expr};
+use crate::engine::core::read::projection::ProjectionPlanner;
+use crate::test_helpers::factories::{CommandFactory, QueryPlanFactory, SchemaRegistryFactory};
+use std::sync::Arc;
+use tempfile::tempdir;
+
+#[tokio::test]
+async fn projection_default_includes_all_payload_and_core() {
+    crate::logging::init_for_tests();
+
+    let factory = SchemaRegistryFactory::new();
+    let registry = factory.registry();
+    factory
+        .define_with_fields(
+            "order",
+            &[("country", "string"), ("plan", "string"), ("amount", "int")],
+        )
+        .await
+        .unwrap();
+
+    let cmd = CommandFactory::query().with_event_type("order").create();
+
+    let plan = QueryPlanFactory::new()
+        .with_command(cmd)
+        .with_registry(Arc::clone(&registry))
+        .with_segment_base_dir(tempdir().unwrap().path())
+        .create()
+        .await;
+
+    let cols = ProjectionPlanner::new(&plan).columns_to_load().await;
+    assert!(cols.contains(&"context_id".to_string()));
+    assert!(cols.contains(&"event_type".to_string()));
+    assert!(cols.contains(&"timestamp".to_string()));
+    // all payload fields
+    assert!(cols.contains(&"country".to_string()));
+    assert!(cols.contains(&"plan".to_string()));
+    assert!(cols.contains(&"amount".to_string()));
+}
+
+#[tokio::test]
+async fn projection_empty_list_behaves_like_all() {
+    let factory = SchemaRegistryFactory::new();
+    let registry = factory.registry();
+    factory
+        .define_with_fields("subscription", &[("country", "string"), ("plan", "string")])
+        .await
+        .unwrap();
+
+    let cmd = Command::Query {
+        event_type: "subscription".into(),
+        context_id: None,
+        since: None,
+        where_clause: None,
+        limit: None,
+        return_fields: Some(vec![]),
+    };
+
+    let plan = QueryPlanFactory::new()
+        .with_command(cmd)
+        .with_registry(Arc::clone(&registry))
+        .with_segment_base_dir(tempdir().unwrap().path())
+        .create()
+        .await;
+
+    let cols = ProjectionPlanner::new(&plan).columns_to_load().await;
+    assert!(cols.contains(&"country".to_string()));
+    assert!(cols.contains(&"plan".to_string()));
+}
+
+#[tokio::test]
+async fn projection_specific_fields_only_plus_core_and_filters() {
+    let factory = SchemaRegistryFactory::new();
+    let registry = factory.registry();
+    factory
+        .define_with_fields("login", &[("device", "string"), ("ip", "string")])
+        .await
+        .unwrap();
+
+    let cmd = Command::Query {
+        event_type: "login".into(),
+        context_id: None,
+        since: None,
+        where_clause: Some(Expr::Compare {
+            field: "device".into(),
+            op: CompareOp::Eq,
+            value: serde_json::json!("ios"),
+        }),
+        limit: None,
+        return_fields: Some(vec!["ip".into()]),
+    };
+
+    let plan = QueryPlanFactory::new()
+        .with_command(cmd)
+        .with_registry(Arc::clone(&registry))
+        .with_segment_base_dir(tempdir().unwrap().path())
+        .create()
+        .await;
+
+    let cols = ProjectionPlanner::new(&plan).columns_to_load().await;
+    // core
+    assert!(cols.contains(&"context_id".to_string()));
+    assert!(cols.contains(&"event_type".to_string()));
+    assert!(cols.contains(&"timestamp".to_string()));
+    // filter column
+    assert!(cols.contains(&"device".to_string()));
+    // projected field
+    assert!(cols.contains(&"ip".to_string()));
+    // excluded field
+    assert!(!cols.contains(&"not_exists".to_string()));
+}
+
+#[tokio::test]
+async fn projection_payload_keyword_is_ignored_and_not_included() {
+    let factory = SchemaRegistryFactory::new();
+    let registry = factory.registry();
+    factory
+        .define_with_fields("payment", &[("amount", "int"), ("currency", "string")])
+        .await
+        .unwrap();
+
+    let cmd = Command::Query {
+        event_type: "payment".into(),
+        context_id: None,
+        since: None,
+        where_clause: None,
+        limit: None,
+        return_fields: Some(vec!["payload".into()]),
+    };
+
+    let plan = QueryPlanFactory::new()
+        .with_command(cmd)
+        .with_registry(Arc::clone(&registry))
+        .with_segment_base_dir(tempdir().unwrap().path())
+        .create()
+        .await;
+
+    let cols = ProjectionPlanner::new(&plan).columns_to_load().await;
+    // Since "payload" is not a valid column, it should not trigger inclusion of all payload
+    assert!(!cols.contains(&"amount".to_string()));
+    assert!(!cols.contains(&"currency".to_string()));
+}
+
+#[tokio::test]
+async fn projection_unknown_field_is_excluded() {
+    let factory = SchemaRegistryFactory::new();
+    let registry = factory.registry();
+    factory
+        .define_with_fields("foo", &[("a", "string")])
+        .await
+        .unwrap();
+
+    let cmd = Command::Query {
+        event_type: "foo".into(),
+        context_id: None,
+        since: None,
+        where_clause: None,
+        limit: None,
+        return_fields: Some(vec!["bar".into()]),
+    };
+
+    let plan = QueryPlanFactory::new()
+        .with_command(cmd)
+        .with_registry(Arc::clone(&registry))
+        .with_segment_base_dir(tempdir().unwrap().path())
+        .create()
+        .await;
+
+    let cols = ProjectionPlanner::new(&plan).columns_to_load().await;
+    assert!(!cols.contains(&"bar".to_string()));
+}
+
+#[tokio::test]
+async fn projection_excludes_unreferenced_payload_fields() {
+    let factory = SchemaRegistryFactory::new();
+    let registry = factory.registry();
+    factory
+        .define_with_fields(
+            "product",
+            &[("name", "string"), ("price", "int"), ("color", "string")],
+        )
+        .await
+        .unwrap();
+
+    // RETURN only name, filter on price; color should not be included
+    let cmd = Command::Query {
+        event_type: "product".into(),
+        context_id: None,
+        since: None,
+        where_clause: Some(Expr::Compare {
+            field: "price".into(),
+            op: CompareOp::Gt,
+            value: serde_json::json!(10),
+        }),
+        limit: None,
+        return_fields: Some(vec!["name".into()]),
+    };
+
+    let plan = QueryPlanFactory::new()
+        .with_command(cmd)
+        .with_registry(Arc::clone(&registry))
+        .with_segment_base_dir(tempdir().unwrap().path())
+        .create()
+        .await;
+
+    let cols = ProjectionPlanner::new(&plan).columns_to_load().await;
+    // core
+    assert!(cols.contains(&"context_id".to_string()));
+    assert!(cols.contains(&"event_type".to_string()));
+    assert!(cols.contains(&"timestamp".to_string()));
+    // filter col
+    assert!(cols.contains(&"price".to_string()));
+    // projected
+    assert!(cols.contains(&"name".to_string()));
+    // not in filters nor projection -> excluded
+    assert!(!cols.contains(&"color".to_string()));
+}

--- a/src/engine/core/read/query_plan.rs
+++ b/src/engine/core/read/query_plan.rs
@@ -89,6 +89,13 @@ impl QueryPlan {
         }
     }
 
+    /// Delegates to the ProjectionPlanner to compute required columns.
+    pub async fn columns_to_load(&self) -> Vec<String> {
+        crate::engine::core::read::projection::ProjectionPlanner::new(self)
+            .columns_to_load()
+            .await
+    }
+
     pub async fn event_type_uid(&self) -> Option<String> {
         let guard = self.registry.read().await;
         let uid = guard.get_uid(self.event_type());

--- a/src/engine/core/zone/zone_hydrator.rs
+++ b/src/engine/core/zone/zone_hydrator.rs
@@ -22,11 +22,8 @@ impl<'a> ZoneHydrator<'a> {
 
         match self.plan.event_type_uid().await {
             Some(uid) => {
-                let columns: Vec<String> = self
-                    .steps
-                    .iter()
-                    .map(|step| step.filter.column.clone())
-                    .collect();
+                // Build minimal column set: filters + projection + core fields
+                let columns = self.plan.columns_to_load().await;
 
                 info!(target: "sneldb::query", "Hydrating zones with columns: {:?}", columns);
 

--- a/tests/integration/scenarios.json
+++ b/tests/integration/scenarios.json
@@ -1,5 +1,19 @@
 [
   {
+    "name": "replay_projection_excludes_unreferenced_payload_field",
+    "input_commands": [
+      "DEFINE product FIELDS { \"name\": \"string\", \"price\": \"int\", \"color\": \"string\" }",
+      "STORE product FOR user-1 PAYLOAD {\"name\":\"Desk\",\"price\":25,\"color\":\"red\"}",
+      "STORE product FOR user-1 PAYLOAD {\"name\":\"Chair\",\"price\":50,\"color\":\"blue\"}",
+      "FLUSH",
+      "REPLAY product FOR user-1 RETURN [name]"
+    ],
+    "matchers": [
+      { "kind": "include_all", "value": ["Desk", "Chair"] },
+      { "kind": "include_none", "value": ["\"color\"", "\"price\""] }
+    ]
+  },
+  {
     "name": "store_without_definition",
     "input_commands": [
       "STORE order_created FOR customer-1 PAYLOAD {\"order_id\":1,\"status\":\"confirmed\"}"
@@ -8,6 +22,29 @@
       "kind": "include",
       "value": "No schema defined"
     }
+  },
+  {
+    "name": "projection_excludes_unreferenced_payload_field",
+    "input_commands": [
+      "DEFINE product FIELDS { \"name\": \"string\", \"price\": \"int\", \"color\": \"string\" }",
+      "STORE product FOR user-1 PAYLOAD {\"name\":\"Desk\",\"price\":25,\"color\":\"red\"}",
+      "FLUSH",
+      "QUERY product RETURN [name] WHERE price > 10"
+    ],
+    "matchers": [
+      {
+        "kind": "include_all",
+        "value": [
+          "Desk"
+        ]
+      },
+      {
+        "kind": "include_none",
+        "value": [
+          "\"color\""
+        ]
+      }
+    ]
   },
   {
     "name": "store_and_query_enum_eq",


### PR DESCRIPTION
### Summary

- Add RETURN clause parsing for QUERY/REPLAY and capture into return_fields.
- Enforce projection based on requested fields; empty list means all payload.
- Add structured tracing for projection decisions.

### Details

- QUERY/REPLAY parsers now populate return_fields: Option<Vec<String>>.
- Projection strictly includes only core fields, filter fields, and schema-known requested fields.
- Logging under target query::projection shows core/filter fields, mode, payload fields, and final columns.